### PR TITLE
No longer force a specific make(1) program

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 LIBPE_DIR = lib/libpe
 PEV_DIR = src
-MAKE = make
 VERSION = 0.71
 ZIPFILE = pev-$(VERSION)-win32.zip
 


### PR DESCRIPTION
Hi pev developers,
as far as I know the $(MAKE) variable is automatically created by the underlying make(1) program in use. It is therefore harmful to enforce it this way, and it breaks the build on platforms where GNU make is not directly available as "make" (such as NetBSD).
In any case, you do require GNU make and it does set $(MAKE), so this change should be safe.
HTH,
-- khorben