### PR TITLE
Fixed building config.c on NetBSD

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -26,6 +26,8 @@
 #include <string.h>
 #if defined(__linux__)
 #include <linux/limits.h>
+#elif defined(__NetBSD__)
+#include <limits.h>
 #elif defined(__APPLE__)
 #include <sys/syslimits.h>
 #elif defined(__CYGWIN__)


### PR DESCRIPTION
Hi pev developers,
config.c does not build at the moment on NetBSD. It makes use of the "PATH_MAX" constant, which according to POSIX should be available from &lt;limits.h&gt;. Another version of this fix would therefore be to unconditionally include this header instead - I simply cannot tell if it really is available on every platform you support at the moment.
Generally wise, I believe it is best to not rely on PATH_MAX to allocate fixed-size buffers for filenames anyway, because some systems do not have any such limitation in the first place.
HTH,
-- khorben