### PR TITLE
Fix missing commas in JSON output

### DIFF
--- a/src/plugins/json.c
+++ b/src/plugins/json.c
@@ -99,6 +99,7 @@ static void to_format(
 					printf(INDENT(--indent, "]"));
 					break;
 			}
+			num_attr++;
 			break;
 		case OUTPUT_TYPE_ATTRIBUTE:
 			if (num_attr > 0)


### PR DESCRIPTION
This is a fix for a minor issue where the various pev tools generate illegal JSON (when used with -f json) in the form of a missing comma.  A comma is omitted where the scope (e.g., an array) it would apply to is empty.

Here is an example of the problem when running readpe on a particular sample:

```json
...snip...
    },
    "Optional/Image header": {
        "Magic number": "0x10b (PE32)",
        "Linker major version": "6",
        "Linker minor version": "0",
        "Size of .text section": "0x2d000",
        "Size of .data section": "0x99a00",
        "Size of .bss section": "0",
        "Entrypoint": "0xc8000",
        "Address of .text section": "0x1000",
        "Address of .data section": "0x1000",
        "ImageBase": "0x400000",
        "Alignment of sections": "0x1000",
        "Alignment factor": "0x200",
        "Major version of required OS": "4",
        "Minor version of required OS": "0",
        "Major version of image": "0",
        "Minor version of image": "0",
        "Major version of subsystem": "4",
        "Minor version of subsystem": "0",
        "Size of image": "0xc9000",
        "Size of headers": "0x400",
        "Checksum": "0xc4c40",
        "Subsystem required": "0x2 (IMAGE_SUBSYSTEM_WINDOWS_GUI)",
        "DLL characteristics": "0",
        "DLL characteristics names": [
        ]
        "Size of stack to reserve": "0x100000",
        "Size of stack to commit": "0x1000",
        "Size of heap space to reserve": "0x100000",
        "Size of heap space to commit": "0x1000"
    },
...snip...
```

Notice that the empty array for "DLL characteristics names" is missing the comma after it.  I uploaded a shared sample to malwr that shows this behavior (```readpe -f json test.data```):

https://malwr.com/analysis/MjM3NmM4NDAzNWRkNDZkYzkzZjdmOTU5MzgwMjRjODQ/

(This is a live malicious PE from the wild, so handle with care.)
