### PR TITLE
Remove const qualifier from parent_scope

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -288,7 +288,7 @@ void output_open_scope(const char *scope_name, output_scope_type_e scope_type) {
 	scope->depth = scope_depth + 1;
 
 	if (scope_depth > 0) {
-		output_scope_t * const parent_scope = NULL;
+		output_scope_t * parent_scope = NULL;
 		STACK_PEEK(g_scope_stack, (void *)&parent_scope);
 		scope->parent_type = parent_scope->type;
 	}


### PR DESCRIPTION
If `parent_scope` is declared as const, the compiler may emit code that assumes the value doesn't change, i.e. dereferencing the null pointer.

https://bugs.debian.org/868554