### PR TITLE
Fix misuse of sprintf() in imphash()

### DIFF
--- a/src/pehash.c
+++ b/src/pehash.c
@@ -489,7 +489,7 @@ static void imphash(pe_ctx_t *ctx, int flavor)
 	memset(imphash_string, 0, imphash_string_size);
 
 	LL_FOREACH_SAFE(head, elt, tmp) \
-		sprintf(imphash_string, "%s%s.%s,", imphash_string, elt->dll_name, elt->function_name); \
+		sprintf(imphash_string + strlen(imphash_string), "%s.%s,", elt->dll_name, elt->function_name); \
 		LL_DELETE(head, elt);
 
 	free(elt);


### PR DESCRIPTION
From the `snprintf` manpage:

> Some programs imprudently rely on code such as the following
>
>     sprintf(buf, "%s some further text", buf);
>
> to append text to buf. However, the standards explicitly note that the results are undefined if source and destination buffers overlap when calling `sprintf()`, `snprintf()`, `vsprintf()`, and `vsnprintf()`. Depending on the version of gcc(1) used, and the compiler options employed, calls such as the above will not produce the expected results.