### PR TITLE
fix readdir bug for linux

### DIFF
--- a/src/pev.conf
+++ b/src/pev.conf
@@ -1,0 +1,1 @@
+plugins_dir=/usr/local/lib/pev/plugins

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -159,10 +159,16 @@ int plugins_load_all_from_directory(const char *path) {
 	// MORE: http://womble.decadent.org.uk/readdir_r-advisory.html
 	// NOTE: readdir is not thread-safe.
 	while ((dir_entry = readdir(dir)) != NULL) {
+
 		switch (dir_entry->d_type) {
 			default: // Unhandled
 				break;
+
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+			case DT_UNKNOWN:
+#else
 			case DT_REG: // Regular file
+#endif
 			{
 				const char *filename = dir_entry->d_name;
 


### PR DESCRIPTION
[root@localhost src]# uname -a
Linux localhost.localdomain 3.10.0-514.26.2.el7.x86_64 #1 SMP Tue Jul 4 15:04:05 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux

[root@localhost src]# cat pev.conf
plugins_dir=/usr/local/lib/pev/plugins

[root@localhost src]# ls -l /usr/local/lib/pev/plugins/
total 76
-rwxr-xr-x 1 root root 12560 Aug 11 18:07 csv_plugin.so
-rwxr-xr-x 1 root root 12744 Aug 11 18:07 html_plugin.so
-rwxr-xr-x 1 root root 12696 Aug 11 18:07 json_plugin.so
-rwxr-xr-x 1 root root  8416 Aug 11 18:07 text_plugin.so
-rwxr-xr-x 1 root root 12688 Aug 11 18:07 xml_plugin.so

[root@localhost src]# ./build/readpe /home/liyl/ent_samples/0222.exe
readpe: output.c:242: output_open_document_with_name: Assertion `g_format != ((void *)0)' failed.
Aborted (core dumped)