### PR TITLE
repack: allocate 1 more byte for NUL character

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -57,7 +57,7 @@
 	exit(EXIT_FAILURE); \
 }
 
-#define MAX_MSG 80
+#define MAX_MSG 81
 #define MAX_PATH 256
 #define VERSION "0.81"
 #define TOOLKIT "from pev " VERSION " <https://github.com/merces/pev/> toolkit"

--- a/src/pepack.c
+++ b/src/pepack.c
@@ -281,14 +281,14 @@ int main(int argc, char *argv[])
 	if (!opendb(&dbfile, options))
 		fprintf(stderr, "WARNING: without valid database file, %s will search in generic mode only\n", PROGRAM);
 
-	static char value[MAX_MSG];
+	static char value[MAX_MSG + 1];
 
 	// TODO(jweyrich): Create a new API to retrieve map_addr.
 	// TODO(jweyrich): Should we use `LIBPE_PTR_ADD(ctx->map_addr, ep_offset)` instead?
 	const unsigned char *pe_data = ctx.map_addr;
 
 	// packer by signature
-	if (compare_signature(pe_data, ep_offset, dbfile, value, sizeof(value)))
+	if (compare_signature(pe_data, ep_offset, dbfile, value, MAX_MSG))
 		;
 	// generic detection
 	else if (generic_packer(&ctx, ep_offset))


### PR DESCRIPTION
strncpy(3) needs 1 more byte for NUL character.

gcc barfs on current code-base:

> warning: '__builtin_strncpy' specified bound 80 equals destination size [-Wstringop-truncation]
>  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));

Also, per comment in https://github.com/merces/pev/pull/154#issuecomment-762512111

MAX_MSG should be 81 not 80.