### PR TITLE
Fix submodule link and close memory leaks

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -104,6 +104,7 @@ static int _load_config_and_parse(pev_config_t * const config, const char *path,
 		size = 0;
 	}
 
+	free( line );
 	fclose(fp);
 
 	return 1;

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -201,8 +201,8 @@ int plugins_load_all_from_directory(const char *path) {
 				}
 
 				int ret = plugins_load(relative_path);
+				free(relative_path);
 				if (ret < 0) {
-					free(relative_path);
 					closedir(dir);
 					return ret;
 				}
@@ -214,7 +214,6 @@ int plugins_load_all_from_directory(const char *path) {
 		}
 	}
 
-	free(relative_path);
 	closedir(dir);
 
 	return load_count;


### PR DESCRIPTION
Just a small merge request.
The pelib submodule was broken (updated to libpe master)

Further two small memory leaks were closed:
- `plugins.c`: in which asptintf allocations were not freed every cycle; The man page says it should use realloc but valgrind reported it as malloc and thus as a leak  and I tend to trust produced code more than the documentation.
- `config.c`: Man pages states that the line pointer has to be freed even on failure/no read.